### PR TITLE
Don’t include region elements when empty

### DIFF
--- a/gst-meet/src/main.rs
+++ b/gst-meet/src/main.rs
@@ -36,8 +36,8 @@ struct Opt {
   video_codec: String,
   #[structopt(long, default_value = "gst-meet")]
   nick: String,
-  #[structopt(long, default_value)]
-  region: String,
+  #[structopt(long)]
+  region: Option<String>,
   #[structopt(long)]
   send_pipeline: Option<String>,
   #[structopt(long)]

--- a/lib-gst-meet-c/src/lib.rs
+++ b/lib-gst-meet-c/src/lib.rs
@@ -135,13 +135,18 @@ pub unsafe extern "C" fn gstmeet_connection_join_conference(
       return ptr::null_mut();
     },
   };
+  let region = if (*config).region.is_null() {
+    None
+  } else {
+    Some(CStr::from_ptr((*config).region)
+      .to_string_lossy()
+      .to_string())
+  };
   let config = JitsiConferenceConfig {
     muc,
     focus,
     nick: CStr::from_ptr((*config).nick).to_string_lossy().to_string(),
-    region: CStr::from_ptr((*config).region)
-      .to_string_lossy()
-      .to_string(),
+    region,
     video_codec: CStr::from_ptr((*config).video_codec)
       .to_string_lossy()
       .to_string(),

--- a/lib-gst-meet/src/conference.rs
+++ b/lib-gst-meet/src/conference.rs
@@ -76,7 +76,7 @@ pub struct JitsiConferenceConfig {
   pub muc: BareJid,
   pub focus: Jid,
   pub nick: String,
-  pub region: String,
+  pub region: Option<String>,
   pub video_codec: String,
   pub extra_muc_features: Vec<String>,
 }
@@ -453,18 +453,22 @@ impl StanzaFilter for JitsiConference {
           Element::builder("jitsi_participant_codecType", "")
             .append(self.config.video_codec.as_str())
             .build(),
-          Element::builder("jitsi_participant_region", "")
-            .append(self.config.region.as_str())
-            .build(),
           Element::builder("audiomuted", "").append("false").build(),
           Element::builder("videomuted", "").append("false").build(),
           Element::builder("nick", "http://jabber.org/protocol/nick")
             .append(self.config.nick.as_str())
             .build(),
-          Element::builder("region", "http://jitsi.org/jitsi-meet")
-            .attr("id", &self.config.region)
-            .build(),
         ];
+        if let Some(region) = &self.config.region {
+          presence.extend([
+            Element::builder("jitsi_participant_region", ns::DEFAULT_NS)
+              .append(region.as_str())
+              .build(),
+            Element::builder("region", "http://jitsi.org/jitsi-meet")
+              .attr("id", region)
+              .build(),
+          ]);
+        }
         presence.extend(
           self
             .config


### PR DESCRIPTION
In small deployments, for instance when there is only one server for all participants, the region doesn’t mean anything so we can remove the elements instead of sending an empty value.