### PR TITLE
add yet another workaround in the xmpp-parsers fork for @name in ssma

### DIFF
--- a/xmpp-parsers/src/jingle_ssma.rs
+++ b/xmpp-parsers/src/jingle_ssma.rs
@@ -10,6 +10,9 @@ generate_element!(
     attributes: [
         /// Maps to the ssrc-id parameter.
         id: Required<String> = "ssrc",
+
+        /// XXX: wtf is that?  It can be either name='jvb-a0' or name='jvb-v0' at avstack’s jicofo.
+        name: Option<String> = "name",
     ],
     children: [
         /// List of attributes for this source.
@@ -27,6 +30,7 @@ impl Source {
             id,
             parameters: Vec::new(),
             info: None,
+            name: None,
         }
     }
 }


### PR DESCRIPTION
This seems to be yet another proprietary extension, jicofo sets it to either `name='jvb-a0'` or `name='jvb-v0'` depending on whether it is an audio or a video content.  I’m tired of these meaningless extensions…