### PR TITLE
Configurable JB size, send PLIs, send loss events, separate RTP/RTCP logging

### DIFF
--- a/lib-gst-meet-c/src/lib.rs
+++ b/lib-gst-meet-c/src/lib.rs
@@ -160,9 +160,11 @@ pub unsafe extern "C" fn gstmeet_connection_join_conference(
     // TODO
     start_bitrate: 800,
     stereo: false,
-    
+    buffer_size: 200,
     #[cfg(feature = "log-rtp")]
     log_rtp: false,
+    #[cfg(feature = "log-rtp")]
+    log_rtcp: false,
   };
   (*context)
     .runtime

--- a/lib-gst-meet/src/conference.rs
+++ b/lib-gst-meet/src/conference.rs
@@ -80,8 +80,11 @@ pub struct JitsiConferenceConfig {
   pub extra_muc_features: Vec<String>,
   pub start_bitrate: u32,
   pub stereo: bool,
+  pub buffer_size: u32,
   #[cfg(feature = "log-rtp")]
   pub log_rtp: bool,
+  #[cfg(feature = "log-rtp")]
+  pub log_rtcp: bool,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
* The jitterbuffer size can now be configured (defaults to 200ms). Smaller values give lower latency, larger values are more resilient to loss and jitter.
* PLIs are now sent automatically when a keyframe is needed (ref. #22)
* Loss & sync events are now sent downstream into the recv pipelines
* RTP and RTCP logging can now be enabled separately