### PR TITLE
add optional syntax highlighting

### DIFF
--- a/lib-gst-meet/Cargo.toml
+++ b/lib-gst-meet/Cargo.toml
@@ -37,6 +37,7 @@ rustls = { version = "0.20", default-features = false, features = ["logging", "t
 rustls-native-certs = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
+syntect = { version = "5", optional = true }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-stream = { version = "0.1", default-features = false, features = ["time"] }
 tokio-tungstenite = { version = "0.17", default-features = false, features = ["connect"] }
@@ -57,6 +58,7 @@ xmpp-parsers = { version = "0.19", default-features = false, features = ["disabl
 # would cause rustls to always be pulled in.
 default = ["tls-rustls-native-roots"]
 log-rtp = ["rtcp"]
+syntax-highlighting = ["syntect"]
 tls-insecure = []
 tls-native = ["tokio-tungstenite/native-tls", "native-tls"]
 tls-native-vendored = ["tokio-tungstenite/native-tls-vendored", "native-tls/vendored"]


### PR DESCRIPTION
This makes debugging XML elements much easier, and doesn’t add any dependency when it is disabled.

![wayland-screenshot-2023-01-25_11-14-24](https://user-images.githubusercontent.com/7755816/214537143-8616171f-c9d3-464f-9ccf-6b3f44d3d41e.png)