### PR TITLE
Add room to query string if not already present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "gstreamer",
  "http",
  "lib-gst-meet",
+ "serde_urlencoded",
  "structopt",
  "tokio",
  "tokio-stream",
@@ -1534,6 +1535,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 

--- a/gst-meet/Cargo.toml
+++ b/gst-meet/Cargo.toml
@@ -14,6 +14,7 @@ glib = { version = "0.17", default-features = false, features = ["log"] }
 gstreamer = { version = "0.20", default-features = false, features = ["v1_20"] }
 http = { version = "0.2", default-features = false }
 lib-gst-meet = { version = "0.7", path = "../lib-gst-meet", default-features = false, features = ["tracing-subscriber"] }
+serde_urlencoded = { version = "0.7", default-features = false }
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-stream = { version = "0.1", default-features = false }


### PR DESCRIPTION
Some Jitsi Meet hosts, including AVStack when multiple shards are used, require the `room` query string parameter to be included when making the XMPP connection.