### PR TITLE
Upgrade jid to 0.10 and xmpp-parsers to 0.20

### DIFF
--- a/gst-meet/src/main.rs
+++ b/gst-meet/src/main.rs
@@ -438,10 +438,10 @@ async fn main_inner() -> Result<()> {
               participant
                 .jid
                 .as_ref()
-                .and_then(|jid| jid.node.as_deref())
+                .and_then(|jid| jid.node_str())
                 .unwrap_or_default(),
             )
-            .replace("{participant_id}", &participant.muc_jid.resource)
+            .replace("{participant_id}", &participant.muc_jid.resource_str())
             .replace("{nick}", &participant.nick.unwrap_or_default());
 
           let bin = gstreamer::parse_bin_from_description(&pipeline_description, false)
@@ -463,7 +463,7 @@ async fn main_inner() -> Result<()> {
 
           bin.set_property(
             "name",
-            format!("participant_{}", participant.muc_jid.resource),
+            format!("participant_{}", participant.muc_jid.resource_str()),
           );
           conference.add_bin(&bin).await?;
         }

--- a/jitsi-xmpp-parsers/Cargo.toml
+++ b/jitsi-xmpp-parsers/Cargo.toml
@@ -10,9 +10,9 @@ documentation = "https://docs.rs/jitsi-xmpp-parsers/"
 authors = ["Jasper Hugo <jasper@avstack.io>"]
 
 [dependencies]
-jid = { version = "0.9", default-features = false, features = ["minidom"] }
+jid = { version = "0.10", default-features = false, features = ["minidom"] }
 minidom = { version = "0.15", default-features = false }
-xmpp-parsers = { version = "0.19", default-features = false, features = ["disable-validation"] }
+xmpp-parsers = { version = "0.20", default-features = false, features = ["disable-validation"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = [ "--sort-modules-by-appearance", "-Zunstable-options" ]

--- a/lib-gst-meet/Cargo.toml
+++ b/lib-gst-meet/Cargo.toml
@@ -22,6 +22,7 @@ gstreamer = { version = "0.20", default-features = false, features = ["v1_20"] }
 gstreamer-rtp = { version = "0.20", default-features = false, features = ["v1_20"] }
 hex = { version = "0.4", default-features = false, features = ["std"] }
 itertools = { version = "0.10", default-features = false, features = ["use_std"] }
+jid = { version = "0.10", default-features = false }
 jitsi-xmpp-parsers = { version = "0.2", path = "../jitsi-xmpp-parsers", default-features = false }
 libc = { version = "0.2", default-features = false }
 maplit = { version = "1", default-features = false }
@@ -51,7 +52,7 @@ tracing-subscriber = { version = "0.3", optional = true, default-features = fals
 ] }
 uuid = { version = "1", default-features = false, features = ["v4"] }
 webpki-roots = { version = "0.23", default-features = false, optional = true }
-xmpp-parsers = { version = "0.19", default-features = false, features = ["disable-validation"] }
+xmpp-parsers = { version = "0.20", default-features = false, features = ["disable-validation"] }
 
 [features]
 # Ideally we would enable rustls/dangerous_configuration only when tls-insecure is enabled, but until weak-dep-features is stabilised, that

--- a/lib-gst-meet/src/jingle.rs
+++ b/lib-gst-meet/src/jingle.rs
@@ -11,6 +11,7 @@ use gstreamer::{
 use gstreamer_rtp::RTPBuffer;
 use gstreamer_rtp::{prelude::RTPHeaderExtensionExt, RTPHeaderExtension};
 use itertools::Itertools;
+use jid::ResourcePart;
 use jitsi_xmpp_parsers::{
   jingle::{Action, Content, Description, Jingle, Transport},
   jingle_dtls_srtp::Fingerprint,
@@ -962,7 +963,8 @@ impl JingleSession {
             };
 
             if let Some(participant_id) = source.participant_id {
-              handle.block_on(conference.ensure_participant(&participant_id))?;
+              handle
+                .block_on(conference.ensure_participant(ResourcePart::new(&participant_id)?))?;
               let maybe_sink_element = match source.media_type {
                 MediaType::Audio => {
                   handle.block_on(conference.remote_participant_audio_sink_element())


### PR DESCRIPTION
The main change is that jid now stores the JID as a single string, with an offset to the `'@'` and to the `'/'`, and stringprep is now always applied.  This lowers the size of the struct in memory, and makes it much faster to display a JID.  In order to also make it fast to run stringprep, there are new `NodePart`, `DomainPart` and `ResourcePart` types which are guaranteed to have been validated/normalized, and thus can be used to construct a JID at the cost of a `format!()` call.

In lib-gst-meet in particular, this removes quite a bunch of `clone()` calls, but nothing significant.

Supersedes #47.