### PR TITLE
Fix Dockerfile to build the new version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM docker.io/library/alpine:3.18.2 AS builder
+FROM docker.io/library/alpine:3.20.0 AS builder
 RUN apk --no-cache --update upgrade --ignore alpine-baselayout \
- && apk --no-cache add build-base gstreamer-dev gst-plugins-base-dev libnice-dev openssl-dev cargo
+ && apk --no-cache add build-base gstreamer-dev gst-plugins-base-dev libnice-dev openssl-dev cargo cmake clang16-libclang rust-bindgen
 COPY . .
 RUN cargo build --release -p gst-meet
 
-FROM docker.io/library/alpine:3.18.2
+FROM docker.io/library/alpine:3.20.0
 RUN apk --update --no-cache upgrade --ignore alpine-baselayout \
  && apk --no-cache add openssl gstreamer gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav libnice libnice-gstreamer
 COPY --from=builder target/release/gst-meet /usr/local/bin


### PR DESCRIPTION
After the switch from ring to aws-lc-rs the Docker build process was broken due to missing dependency.

This PR  : 
- Add cmake, clang16-libclang  and rust-bindgen in build step package installation.
- Update the Alpine base image version to 3.20.0.